### PR TITLE
feat: unified dependencies (kps-1319)

### DIFF
--- a/charts/kompass/Chart.yaml
+++ b/charts/kompass/Chart.yaml
@@ -1,25 +1,50 @@
 apiVersion: v2
 name: kompass
-description: Helm chart for Kompass
+description: Zesty Kompass Helm Charts
 
 type: application
 version: 0.1.2
 appVersion: "1.16.0"
 
 dependencies:
+# zesty products
   - name: kompass-insights
-    version: "2.1.4"
     alias: insights
     repository: "https://zesty-co.github.io/kompass-insights"
+    version: "2.1.7"
 
   - name: pod-rightsizing
-    version: 0.1.3
     alias: rightsizing
-    repository: "https://zesty-co.github.io/kompass-pod-rightsizing"
     condition: rightsizing.enabled
+    repository: "https://zesty-co.github.io/kompass-pod-rightsizing"
+    version: 0.1.3
 
   - name: zesty
-    version: 1.7.0
     alias: disk
-    repository: "https://zesty-co.github.io/zesty-helm"
     condition: disk.enabled
+    repository: "https://zesty-co.github.io/zesty-helm"
+    version: 1.7.0
+
+# mutual dependencies
+  - name: victoria-metrics-single
+    alias: victoriaMetrics
+    condition: victoriaMetrics.enabled
+    repository: https://victoriametrics.github.io/helm-charts
+    version: 0.14.3
+
+  - name: victoria-metrics-agent
+    alias: victoriaMetricsAgent
+    condition: victoriaMetrics.enabled
+    repository: https://victoriametrics.github.io/helm-charts
+    version: 0.16.2
+
+  - name: kube-state-metrics
+    alias: kubeStateMetrics
+    condition: kubeStateMetrics.enabled
+    repository: https://prometheus-community.github.io/helm-charts
+    version: ">=5.28.0"
+
+  - name: grafana
+    condition: grafana.enabled
+    repository: https://grafana.github.io/helm-charts
+    version: 8.10.4

--- a/charts/kompass/files/grafana-dashboard.json
+++ b/charts/kompass/files/grafana-dashboard.json
@@ -1,0 +1,1354 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_VICTORIAMETRICS",
+      "label": "VictoriaMetrics",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.5.2"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "VictoriaMetrics"
+        },
+        "enable": true,
+        "expr": "changes(pilot_recommendations{container=\"$container\", type=\"orchestration\"}[1m])",
+        "hide": false,
+        "iconColor": "blue",
+        "name": "Orchestrations",
+        "tagKeys": "",
+        "textFormat": "",
+        "titleFormat": "Orchestration {{container}}"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "VictoriaMetrics"
+        },
+        "enable": true,
+        "expr": "changes(pilot_recommendations{container=\"$container\", type=\"rollback\"}[1m])",
+        "hide": false,
+        "iconColor": "red",
+        "name": "Rollbacks",
+        "titleFormat": "Rollback {{container}}"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepBefore",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Usage"
+            },
+            "properties": [
+              {
+                "id": "custom.fillOpacity",
+                "value": 13
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Desired"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    40
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 4
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Requests"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 11
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "MAX Strategy"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 1
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "MAX Strategy"
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "max(rate(container_cpu_usage_seconds_total{container=\"$container\"}[1m])) by (container) < 5",
+          "instant": true,
+          "legendFormat": "Usage: {{container}}",
+          "range": true,
+          "refId": "Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "avg(pilot_recommendations{container=\"$container\", resource_type=\"cpu\"}[15s:15s])[1d]",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Desired: {{container}}",
+          "range": true,
+          "refId": "Desired"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(avg(kube_pod_container_resource_requests{resource=\"cpu\", container=\"$container\"}) by(container, id))[5m]",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Requests: {{container}}",
+          "range": true,
+          "refId": "Requests"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "max(max_over_time(rate(container_cpu_usage_seconds_total{container=\"$container\"}[1m])[$LookbackPeriod]) * on (container, pod) group_left (created_by_name, created_by_kind, namespace) max(max_over_time(pilot_pod_info[$LookbackPeriod])) by (container, pod, created_by_name, created_by_kind, namespace)[$LookbackPeriod]) by (container, created_by_name, created_by_kind, namespace) * (\"$Strategy\" == 'Conservative' or \"$Strategy\" == 'All') * (1 + $BufferPercent/100)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Conservative Strategy: {{container}}",
+          "range": true,
+          "refId": "Conservative Strategy"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "quantile_over_time(\n    0.95, max(\n        rate(\n            container_cpu_usage_seconds_total{container=\"$container\"}[1m]\n        ) * on (container, pod) group_left (created_by_name, created_by_kind, namespace) max(max_over_time(pilot_pod_info[$LookbackPeriod])) by (container, pod, created_by_name, created_by_kind, namespace)\n    ) by (container) [$LookbackPeriod]\n) * (\"$Strategy\" == 'Default' or \"$Strategy\" == 'All') * (1 + $BufferPercent/100)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Default Strategy: {{container}}",
+          "range": true,
+          "refId": "Default Strategy"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "quantile_over_time(\n    0.50, max(\n        rate(\n            container_cpu_usage_seconds_total{container=\"$container\"}[1m]\n        ) * on (container, pod) group_left (created_by_name, created_by_kind, namespace) max(max_over_time(pilot_pod_info[$LookbackPeriod])) by (container, pod, created_by_name, created_by_kind, namespace)\n    ) by (container) [$LookbackPeriod]\n) * (\"$Strategy\" == 'Aggressive' or \"$Strategy\" == 'All') * (1 + $BufferPercent/100)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Aggressive Strategy: {{container}}",
+          "range": true,
+          "refId": "Aggressive Strategy"
+        }
+      ],
+      "title": "Cpu Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepBefore",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Requests"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#ff7b00",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 8
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Desired"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    40
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 5
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Usage"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-orange",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 21
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Dry Run Memory"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max_over_time(max(container_memory_usage_bytes{container=\"$container\"}) by (container))[1m] / 1024 / 1024",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Usage: {{container}}",
+          "range": true,
+          "refId": "Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "avg(pilot_recommendations{container=\"$container\", resource_type=\"memory\"}[15s:15s])[1d] / 1024 / 1024",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Desired: {{container}}",
+          "range": true,
+          "refId": "Desired"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(avg(kube_pod_container_resource_requests{resource=\"memory\", container=\"$container\"}) by(container))[1m] / 1024 / 1024",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Requests: {{container}}",
+          "range": true,
+          "refId": "Requests"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "max(max_over_time(container_memory_usage_bytes{container=\"$container\"}[$LookbackPeriod]) * on (container, pod) group_left (created_by_name, created_by_kind, namespace) max(max_over_time(pilot_pod_info[$LookbackPeriod])) by (container, pod, created_by_name, created_by_kind, namespace)[$LookbackPeriod]) by (container, created_by_name, created_by_kind, namespace) / 1024 / 1024 * (\"$Strategy\" == 'Conservative' or \"$Strategy\" == 'All') * (1 + $BufferPercent/100)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Conservative Strategy: {{container}}",
+          "range": true,
+          "refId": "Conservative Strategy"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "quantile_over_time(\n    0.99, \n    max(container_memory_usage_bytes{container=\"$container\"} * on (container, pod) group_left (created_by_name, created_by_kind, namespace) max(max_over_time(pilot_pod_info[$LookbackPeriod])) by (container, pod, created_by_name, created_by_kind, namespace)) by (container) [$LookbackPeriod]\n) / 1024 / 1024 * (\"$Strategy\" == 'Default' or \"$Strategy\" == 'All') * (1 + $BufferPercent/100)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Default Strategy: {{container}}",
+          "range": true,
+          "refId": "Default Strategy"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "quantile_over_time(\n    0.50, \n    max(container_memory_usage_bytes{container=\"$container\"} * on (container, pod) group_left (created_by_name, created_by_kind, namespace) max(max_over_time(pilot_pod_info[$LookbackPeriod])) by (container, pod, created_by_name, created_by_kind, namespace)) by (container) [$LookbackPeriod]\n) / 1024 / 1024 * (\"$Strategy\" == 'Aggressive' or \"$Strategy\" == 'All') * (1 + $BufferPercent/100)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Aggressive Strategy: {{container}}",
+          "range": true,
+          "refId": "Aggressive Strategy"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": 3600000,
+            "lineInterpolation": "stepBefore",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "count(kube_pod_container_info{container=\"$container\"})",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Replicas Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Failed Requests"
+            },
+            "properties": [
+              {
+                "id": "custom.fillOpacity",
+                "value": 62
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 8
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(container_cpu_cfs_throttled_seconds_total{container=\"$container\"}[5m]) * on (container, pod, namespace) group_left (created_by_name, created_by_kind) max(max_over_time(pilot_pod_info{container=\"$container\"}[5m])) by (container, pod, created_by_name, created_by_kind, namespace)) by (container, namespace, created_by_name, created_by_kind)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "CPU Throttling time"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "sum((delta(kube_pod_container_status_restarts_total{container=\"$container\"}[1m])  > 0) * on (pod, container, namespace) (kube_pod_container_status_last_terminated_reason{reason=\"OOMKilled\", container=\"$container\"}  > 0) * on (container, pod, namespace) group_left (created_by_name, created_by_kind) max(pilot_pod_info{container=\"$container\"}) by (container, pod, namespace, created_by_name, created_by_kind)) by (container, created_by_name, created_by_kind, namespace)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "OOM Events"
+        }
+      ],
+      "title": "Events (Throttling/OOM)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepBefore",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 3600000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Dry Run HPA_CPU"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73bf696e",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Dry Run HPA_Memory"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#fade2a6e",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "kube_horizontalpodautoscaler_spec_target_metric{metric_name=\"cpu\"} * on (horizontalpodautoscaler) group_left () kube_horizontalpodautoscaler_info{scaletargetref_name=\"$workload_name\"}",
+          "legendFormat": "HPA CPU",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "kube_horizontalpodautoscaler_spec_target_metric{metric_name=\"memory\"} * on (horizontalpodautoscaler) group_left () kube_horizontalpodautoscaler_info{scaletargetref_name=\"$workload_name\"}",
+          "hide": false,
+          "legendFormat": "HPA Memory",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "pilot_recommendations{resource_type=\"hpa_cpu\", mode=\"live\", name=\"$workload_name\", resource_source=\"desired\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Desired Hpa CPU",
+          "range": true,
+          "refId": "HPA_CPU_desired"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "pilot_recommendations{resource_type=\"hpa_memory\", mode=\"live\", name=\"$workload_name\", resource_source=\"desired\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Desired Hpa Memory",
+          "range": true,
+          "refId": "HPA_Memory_desired"
+        }
+      ],
+      "title": "HPA",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text",
+              "wrapText": false
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 170
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": true,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Time"
+          }
+        ]
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "expr": "pilot_recommendations{name=\"$workload_name\", mode=\"live\"}[15:15]",
+          "format": "table",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Audit table",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "VictoriaMetrics"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 8,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "VictoriaMetrics"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "Errors",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Errors",
+      "type": "table"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 40,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "definition": "query_result(sort(  label_replace(kube_deployment_metadata_generation, \"name\", \"$1\", \"deployment\", \"(.+)\") or  label_replace(kube_statefulset_metadata_generation, \"name\", \"$1\", \"statefulset\", \"(.+)\") or  label_replace(kube_daemonset_metadata_generation, \"name\", \"$1\", \"daemonset\", \"(.+)\")))",
+        "label": "Workload Name",
+        "name": "workload_name",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(sort(  label_replace(kube_deployment_metadata_generation, \"name\", \"$1\", \"deployment\", \"(.+)\") or  label_replace(kube_statefulset_metadata_generation, \"name\", \"$1\", \"statefulset\", \"(.+)\") or  label_replace(kube_daemonset_metadata_generation, \"name\", \"$1\", \"daemonset\", \"(.+)\")))",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/.*name=\"([^\"]*).*/",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "query_result( kube_pod_container_info{} * on(pod)   group_left(created_by_name)   kube_pod_info{created_by_name=~\"$workload_name.*\"})",
+        "name": "container",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result( kube_pod_container_info{} * on(pod)   group_left(created_by_name)   kube_pod_info{created_by_name=~\"$workload_name.*\"})",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/container=\"([^\"]*)\"/",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "Conservative",
+          "value": "Conservative"
+        },
+        "name": "Strategy",
+        "options": [
+          {
+            "selected": false,
+            "text": "Default",
+            "value": "Default"
+          },
+          {
+            "selected": false,
+            "text": "Aggressive",
+            "value": "Aggressive"
+          },
+          {
+            "selected": true,
+            "text": "Conservative",
+            "value": "Conservative"
+          },
+          {
+            "selected": false,
+            "text": "All",
+            "value": "All"
+          },
+          {
+            "selected": false,
+            "text": "None",
+            "value": "None"
+          }
+        ],
+        "query": "Default, Aggressive, Conservative, All, None",
+        "type": "custom"
+      },
+      {
+        "current": {
+          "text": "30",
+          "value": "30"
+        },
+        "name": "BufferPercent",
+        "options": [
+          {
+            "selected": false,
+            "text": "0",
+            "value": "0"
+          },
+          {
+            "selected": false,
+            "text": "10",
+            "value": "10"
+          },
+          {
+            "selected": false,
+            "text": "20",
+            "value": "20"
+          },
+          {
+            "selected": true,
+            "text": "30",
+            "value": "30"
+          },
+          {
+            "selected": false,
+            "text": "40",
+            "value": "40"
+          },
+          {
+            "selected": false,
+            "text": "50",
+            "value": "50"
+          },
+          {
+            "selected": false,
+            "text": "60",
+            "value": "60"
+          },
+          {
+            "selected": false,
+            "text": "70",
+            "value": "70"
+          },
+          {
+            "selected": false,
+            "text": "80",
+            "value": "80"
+          },
+          {
+            "selected": false,
+            "text": "90",
+            "value": "90"
+          }
+        ],
+        "query": "0, 10, 20, 30, 40, 50, 60, 70, 80, 90",
+        "type": "custom"
+      },
+      {
+        "current": {},
+        "definition": "query_result(kube_pod_container_info{}     * on (pod)     group_left()     last_over_time(kube_pod_annotations{annotation_kompass_io_rightsizing=\"true\"}[1h]))",
+        "hide": 2,
+        "name": "containerDEPRECATED",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(kube_pod_container_info{}     * on (pod)     group_left()     last_over_time(kube_pod_annotations{annotation_kompass_io_rightsizing=\"true\"}[1h]))",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/container=\"(?<text>.+?)\"/g",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "1d",
+          "value": "1d"
+        },
+        "description": "",
+        "name": "LookbackPeriod",
+        "options": [
+          {
+            "selected": true,
+            "text": "1d",
+            "value": "1d"
+          }
+        ],
+        "query": "1d",
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s"
+    ]
+  },
+  "timezone": "",
+  "title": "Pod-RightSizing Dashboard",
+  "uid": "d86fc2f1-c942-4sc3-b575-93345113be8d",
+  "version": 1,
+  "weekStart": ""
+}

--- a/charts/kompass/templates/_helpers.tpl
+++ b/charts/kompass/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/*
+Helper Templates for Kompass Insights
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "zesty-k8s.name" -}}
+  {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "prefix.name" -}}
+  {{- default "zesty-k8s" .Values.prefix | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "name" -}}
+  {{- printf "%s-%s" (include "prefix.name" .) .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "zesty-k8s.fullname" -}}
+  {{- if .Values.fullnameOverride }}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+  {{- else }}
+    {{- $name := default .Chart.Name .Values.nameOverride }}
+    {{- if contains $name .Release.Name }}
+      {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+    {{- else }}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "zesty-k8s.chart" -}}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "kube-state-metrics.serviceName" -}}
+  {{- if .Values.kubeStateMetrics.enabled }}
+    {{- .Values.kubeStateMetrics.fullnameOverride | trunc 63 | trimSuffix "-" }}
+  {{- else }}
+    {{- .Values.kubeStateMetrics.serviceName | trunc 63 | trimSuffix "-" }}
+  {{- end }}
+{{- end }}
+
+{{- define "zesty-k8s.labels" -}}
+helm.sh/chart: {{ include "zesty-k8s.chart" . }}
+{{ include "zesty-k8s.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "zesty-k8s.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "zesty-k8s.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/kompass/templates/_helpers.tpl
+++ b/charts/kompass/templates/_helpers.tpl
@@ -5,12 +5,12 @@ Helper Templates for Kompass Insights
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "zesty-k8s.name" -}}
+{{- define "kompass.name" -}}
   {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{- define "prefix.name" -}}
-  {{- default "zesty-k8s" .Values.prefix | trunc 63 | trimSuffix "-" }}
+  {{- default "kompass" .Values.prefix | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{- define "name" -}}
@@ -22,7 +22,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "zesty-k8s.fullname" -}}
+{{- define "kompass.fullname" -}}
   {{- if .Values.fullnameOverride }}
     {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
   {{- else }}
@@ -38,7 +38,7 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "zesty-k8s.chart" -}}
+{{- define "kompass.chart" -}}
   {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -50,9 +50,9 @@ Create chart name and version as used by the chart label.
   {{- end }}
 {{- end }}
 
-{{- define "zesty-k8s.labels" -}}
-helm.sh/chart: {{ include "zesty-k8s.chart" . }}
-{{ include "zesty-k8s.selectorLabels" . }}
+{{- define "kompass.labels" -}}
+helm.sh/chart: {{ include "kompass.chart" . }}
+{{ include "kompass.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -62,7 +62,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "zesty-k8s.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "zesty-k8s.name" . }}
+{{- define "kompass.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kompass.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/kompass/templates/dependencies/grafanaCharts.yaml
+++ b/charts/kompass/templates/dependencies/grafanaCharts.yaml
@@ -4,10 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "name" . }}-grafana-dashboard
   labels:
-    {{- include "zesty-k8s.labels" . | nindent 4 }}
+    {{- include "kompass.labels" . | nindent 4 }}
     grafana_dashboard: "1"
 data:
-  zesty-k8s-grafana-dashboard.json: |-
+  kompass-grafana-dashboard.json: |-
 {{ .Files.Get "files/grafana-dashboard.json" | indent 4 }}
 {{- end }}
 ---
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "name" . }}-grafana-datasource
   labels:
-    {{- include "zesty-k8s.labels" . | nindent 4 }}
+    {{- include "kompass.labels" . | nindent 4 }}
     grafana_datasource: "1"
 data:
   datasource.yaml: |-

--- a/charts/kompass/templates/dependencies/grafanaCharts.yaml
+++ b/charts/kompass/templates/dependencies/grafanaCharts.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.grafana.enabled .Values.grafana.deployDashboard}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "name" . }}-grafana-dashboard
+  labels:
+    {{- include "zesty-k8s.labels" . | nindent 4 }}
+    grafana_dashboard: "1"
+data:
+  zesty-k8s-grafana-dashboard.json: |-
+{{ .Files.Get "files/grafana-dashboard.json" | indent 4 }}
+{{- end }}
+---
+{{- if and .Values.grafana.enabled .Values.grafana.deployDataSource}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "name" . }}-grafana-datasource
+  labels:
+    {{- include "zesty-k8s.labels" . | nindent 4 }}
+    grafana_datasource: "1"
+data:
+  datasource.yaml: |-
+    apiVersion: 1
+    datasources:
+    - name: VictoriaMetrics
+      type: prometheus
+      url: http://{{ .Values.victoriaMetrics.server.fullnameOverride}}.{{ .Release.Namespace }}:8428
+      access: proxy
+      isDefault: true
+      editable: false
+{{- end }}

--- a/charts/kompass/templates/dependencies/vmagentCharts.yaml
+++ b/charts/kompass/templates/dependencies/vmagentCharts.yaml
@@ -65,6 +65,14 @@ data:
             regex: '.*'
             action: keep
 
+{{- if .Values.rightsizing.enabled }}
+      # for collecting Pilot metrics
+      - job_name: 'pilot'
+        scrape_interval: 30s
+        static_configs:
+          - targets: ['http://{{ include "recommendations-maker.name" . }}.{{ .Release.Namespace }}:{{ .Values.rightsizing.recommendationsMaker.port }}']
+{{- end -}}
+
       # for collecting VM metrics
       - job_name: 'vmetrics'
         scrape_interval: 30s

--- a/charts/kompass/templates/dependencies/vmagentCharts.yaml
+++ b/charts/kompass/templates/dependencies/vmagentCharts.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.victoriaMetrics.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vmagent
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vmagent
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/metrics
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vmagent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vmagent
+subjects:
+  - kind: ServiceAccount
+    name: vmagent
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vmagent-config
+  namespace: {{ .Release.Namespace }}
+data:
+  vmagent-config.yaml: |
+    scrape_configs:
+      # For container CPU and memory metrics
+      - job_name: 'kubelet'
+        scrape_interval: 30s
+        scheme: https
+        tls_config:
+          insecure_skip_verify: true
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        authorization:
+          credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_node_name]
+            target_label: node
+          - target_label: __metrics_path__
+            replacement: /metrics/cadvisor
+          - source_labels: [__meta_kubernetes_node_address_InternalIP]
+            target_label: __address__
+            replacement: ${1}:10250
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: '.*'
+            action: keep
+
+      # for collecting VM metrics
+      - job_name: 'vmetrics'
+        scrape_interval: 30s
+        static_configs:
+          - targets: ['{{ .Values.victoriaMetrics.server.fullnameOverride}}.{{ .Release.Namespace }}:8428']
+
+      # For pod and node metrics
+      - job_name: 'kube-state-metrics'
+        scrape_interval: 30s
+        kubernetes_sd_configs:
+          - role: service
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_name]
+            regex: {{ include "kube-state-metrics.serviceName" . }}
+            action: keep
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: '.*'
+            action: keep
+{{- end -}}

--- a/charts/kompass/values.yaml
+++ b/charts/kompass/values.yaml
@@ -58,3 +58,74 @@ disk:
     # -- (string) REQUIRED if disk.enabled is true: The Zesty API Key for disk agent management.
     # Provided during the onboarding process.
     apiKey: ""
+
+victoriaMetrics:
+  enabled: false
+  serviceAccount:
+    name: zesty-kompass-victoria-metrics
+  server:
+    fullnameOverride: zesty-kompass-victoria-metrics
+    persistentVolume:
+      mountPath: /victoria-metrics-data
+      size: "30Gi"
+      storageClassName: "ebs-sc"
+    resources:
+      requests:
+        memory: "3Gi"
+        cpu: "0.5"
+    extraArgs:
+      retentionPeriod: 1w
+      storageDataPath: /victoria-metrics-data
+      search.maxStalenessInterval: 5m
+      search.minStalenessInterval: 30s
+      search.maxQueryDuration: 2m
+      search.disableCache: true
+      memory.allowedPercent: 60
+      dedup.minScrapeInterval: 30s
+
+victoriaMetricsAgent:
+  fullnameOverride: zesty-kompass-victoria-metrics-agent
+  serviceAccount:
+    name: zesty-kompass-victoria-metrics-agent
+  service:
+    type: ClusterIP
+  extraArgs:
+    promscrape.config: /etc/vmagent-config/vmagent-config.yaml
+  remoteWrite:
+    - url: http://zesty-kompass-victoria-metrics.zesty-system:8428/api/v1/write
+  extraVolumes:
+    - name: config
+      configMap:
+        name: vmagent-config
+  extraVolumeMounts:
+    - name: config
+      mountPath: /etc/vmagent-config
+
+kubeStateMetrics:
+  enabled: false
+  serviceName: ""
+  nameOverride: kube-state-metrics
+  fullnameOverride: zesty-kompass-kube-state-metrics
+  extraArgs:
+    - --metric-annotations-allowlist=pods=[*]
+
+grafana:
+  enabled: false
+  fullnameOverride: "zesty-kompass-grafana"
+  deployDataSource: true
+  deployDashboard: true
+  persistence:
+    enabled: true
+    type: "statefulset"
+    size: 1Gi
+    storageClassName: "ebs-sc"
+  # Use ConfigMaps for datasources and dashboards
+  sidecar:
+    datasources:
+      enabled: true
+      label: grafana_datasource
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+  adminUser: admin
+  adminPassword: password


### PR DESCRIPTION
Added dependencies for:
- victoriametrics
- victoriametrics-agent
- kube-state-metrics
- grafana

Kompass-Insights can still install them on its own but by default it won't (and we can remove them from it later)

Note: grafana configuration was taken from the pod-rightsizing charts a week ago and is a bit outdated