### PR TITLE
feat: Push recommendation data to Victoria Metrics (KPS-1710)

### DIFF
--- a/.github/workflows/jenkins.yaml
+++ b/.github/workflows/jenkins.yaml
@@ -71,7 +71,7 @@ jobs:
           BUILD_URL="${{ steps.get_build_number.outputs.build_url }}"
           BUILD_STATUS=""
           echo "Waiting for build at $BUILD_URL to complete..."
-          TIMEOUT_SECONDS=1200
+          TIMEOUT_SECONDS=1800
           INTERVAL_SECONDS=30
           END_TIME=$((SECONDS + TIMEOUT_SECONDS))
 

--- a/charts/kompass/Chart.yaml
+++ b/charts/kompass/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
   - name: kompass-insights
     alias: insights
     repository: "https://zesty-co.github.io/kompass-insights"
-    version: "2.1.16"
+    version: "2.1.17"
 
   - name: pod-rightsizing
     alias: rightsizing

--- a/charts/kompass/Chart.yaml
+++ b/charts/kompass/Chart.yaml
@@ -3,7 +3,7 @@ name: kompass
 description: Zesty Kompass Helm Charts
 
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "1.16.0"
 
 dependencies:
@@ -11,7 +11,7 @@ dependencies:
   - name: kompass-insights
     alias: insights
     repository: "https://zesty-co.github.io/kompass-insights"
-    version: "2.1.14"
+    version: "2.1.16"
 
   - name: pod-rightsizing
     alias: rightsizing

--- a/charts/kompass/Chart.yaml
+++ b/charts/kompass/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
   - name: kompass-insights
     alias: insights
     repository: "https://zesty-co.github.io/kompass-insights"
-    version: "2.1.17"
+    version: "2.1.18"
 
   - name: pod-rightsizing
     alias: rightsizing

--- a/charts/kompass/templates/dependencies/vmagentCharts.yaml
+++ b/charts/kompass/templates/dependencies/vmagentCharts.yaml
@@ -71,13 +71,21 @@ data:
         scrape_interval: 30s
         static_configs:
           - targets: ['http://{{ include "recommendations-maker.name" . }}.{{ .Release.Namespace }}:{{ .Values.rightsizing.recommendationsMaker.port }}']
-{{- end -}}
+{{- end }}
 
       # for collecting VM metrics
       - job_name: 'vmetrics'
         scrape_interval: 30s
         static_configs:
           - targets: ['{{ .Values.victoriaMetrics.server.fullnameOverride}}.{{ .Release.Namespace }}:8428']
+
+      {{- if .Values.insights.recommendations.enabled }}
+      # for collecting recommendations
+      - job_name: 'recommendations'
+        scrape_interval: 30s
+        static_configs:
+          - targets: ['http://{{ include "zesty-k8s.recommendations.fullname" (dict "Values" .Values.insights "Release" .Release "Chart" (dict "Name" "insights")) }}.{{ .Release.Namespace }}:{{ .Values.insights.recommendations.http.port }}']
+      {{- end }}
 
       # For pod and node metrics
       - job_name: 'kube-state-metrics'

--- a/charts/kompass/values.yaml
+++ b/charts/kompass/values.yaml
@@ -82,7 +82,7 @@ victoriaMetrics:
       search.disableCache: true
       memory.allowedPercent: 60
       dedup.minScrapeInterval: 30s
-      search.cacheTimestampOffset: 7d
+      search.cacheTimestampOffset: 168h
 
 victoriaMetricsAgent:
   fullnameOverride: zesty-kompass-victoria-metrics-agent


### PR DESCRIPTION
- Fixed Victoria Metrics' `search.cacheTimestampOffset` parameter
- Add scraping of recommendations service endpoint
- Increased Jenkins pipeline timeout to 30 minutes (tests took 21-22 minutes to finish)