### PR TITLE
fix: remove duplicate VictoriaMetrics resources

### DIFF
--- a/charts/kompass/Chart.yaml
+++ b/charts/kompass/Chart.yaml
@@ -4,7 +4,7 @@ description: Zesty Kompass Helm Charts
 icon: https://zesty.co/wp-content/uploads/2024/05/favicon-150x150.png
 
 type: application
-version: 0.1.65
+version: 0.1.66
 appVersion: "1.16.0"
 
 dependencies:

--- a/charts/kompass/templates/dependencies/vm-configs.yaml
+++ b/charts/kompass/templates/dependencies/vm-configs.yaml
@@ -1,45 +1,11 @@
 {{- if .Values.victoriaMetrics.enabled }}
 apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: vmagent
-  namespace: {{ .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: vmagent
-rules:
-  - apiGroups: [""]
-    resources:
-      - nodes
-      - nodes/metrics
-      - nodes/proxy
-      - services
-      - endpoints
-      - pods
-    verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: vmagent
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: vmagent
-subjects:
-  - kind: ServiceAccount
-    name: vmagent
-    namespace: {{ .Release.Namespace }}
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kompass-vmagent-config
   namespace: {{ .Release.Namespace }}
 data:
-  vmagent-config.yaml: |
+  scrape.yml: |
     scrape_configs:
       # For container CPU and memory metrics
       - job_name: 'kubelet'

--- a/charts/kompass/values.yaml
+++ b/charts/kompass/values.yaml
@@ -128,18 +128,11 @@ victoriaMetricsAgent:
     name: kompass-victoria-metrics-agent
   service:
     type: ClusterIP
+  configMap: kompass-vmagent-config
   extraArgs:
-    promscrape.config: /etc/vmagent-config/vmagent-config.yaml
     promscrape.maxScrapeSize: 128MB
   remoteWrite:
     - url: *vmRemoteWriteUrl
-  extraVolumes:
-    - name: config
-      configMap:
-        name: kompass-vmagent-config
-  extraVolumeMounts:
-    - name: config
-      mountPath: /etc/vmagent-config
 
 victoriaMetricsAlert:
   fullnameOverride: kompass-victoria-metrics-alert


### PR DESCRIPTION
We are currently creating orphaned resources.
I assume this is a remainder from the chart migrations.

This PR solves two problems:

# Problem 1: Duplicate ServiceAccount/RBAC

- Before: Created vmagent ServiceAccount + ClusterRole + ClusterRoleBinding manually
- Reality: The vmagent Deployment uses serviceAccountName: kompass-victoria-metrics-agent (from subchart)
- Result: Manual RBAC was orphaned - created but never used
- Fix: Removed the orphaned resources. Only subchart's ServiceAccount exists now.

# Problem 2: Duplicate ConfigMaps

- Before:
  - Subchart generates kompass-victoria-metals-agent-config (default scrape config)
   - We create kompass-vmagent-config (custom scrape config)
   - We tell vmagent to use custom via promscrape.config arg
   - Default ConfigMap generated but ignored = wasted resources
- Fix: Use subchart's configMap parameter: [See here](https://github.com/VictoriaMetrics/helm-charts/blob/master/charts/victoria-metrics-agent/values.yaml#L317-L320)
   - When configMap: "name" is set, subchart skips generating default ConfigMap
   - It directly mounts our specified ConfigMap instead
   - **Result**: Only one ConfigMap exists and is used