### PR TITLE
Allow insights to GET rightsizing resources

### DIFF
--- a/charts/kompass-insights/Chart.yaml
+++ b/charts/kompass-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kompass-insights
 description: Kompass Insights for K8s
 type: application
-version: 2.1.96
+version: 2.1.97
 appVersion: "v1.161.0"
 
 dependencies:

--- a/charts/kompass-insights/templates/clusterRole.yaml
+++ b/charts/kompass-insights/templates/clusterRole.yaml
@@ -12,6 +12,7 @@ rules:
       - policies
       - actions
     verbs:
+      - get
       - list
       - watch
   - apiGroups:

--- a/charts/kompass/Chart.yaml
+++ b/charts/kompass/Chart.yaml
@@ -3,7 +3,7 @@ name: kompass
 description: Zesty Kompass Helm Charts
 icon: https://zesty.co/wp-content/uploads/2024/05/favicon-150x150.png
 type: application
-version: 0.2.2
+version: 0.2.1
 appVersion: "1.16.0"
 dependencies:
   # zesty products

--- a/charts/kompass/Chart.yaml
+++ b/charts/kompass/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
   - name: kompass-insights
     condition: kompass-insights.enabled
     repository: "https://zesty-co.github.io/kompass"
-    version: "2.1.97"
+    version: "2.1.96"
   - name: pod-rightsizing
     alias: rightsizing
     repository: "https://zesty-co.github.io/kompass-pod-rightsizing"

--- a/charts/kompass/Chart.yaml
+++ b/charts/kompass/Chart.yaml
@@ -3,14 +3,14 @@ name: kompass
 description: Zesty Kompass Helm Charts
 icon: https://zesty.co/wp-content/uploads/2024/05/favicon-150x150.png
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "1.16.0"
 dependencies:
   # zesty products
   - name: kompass-insights
     condition: kompass-insights.enabled
     repository: "https://zesty-co.github.io/kompass"
-    version: "2.1.96"
+    version: "2.1.97"
   - name: pod-rightsizing
     alias: rightsizing
     repository: "https://zesty-co.github.io/kompass-pod-rightsizing"


### PR DESCRIPTION
## Summary
- grant Kompass Insights the ability to `get` rightsizing policies and actions via its ClusterRole
- bump the Kompass Insights chart and umbrella Kompass chart versions so the fix lands in released charts

## Testing
- Not Run (not requested)
