### PR TITLE
Enable Grafana by default

### DIFF
--- a/.github/workflows/release-ecr.yaml
+++ b/.github/workflows/release-ecr.yaml
@@ -51,6 +51,7 @@ jobs:
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add jetstack https://charts.jetstack.io
+          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
           helm repo update
 
       - name: Package Chart

--- a/charts/kompass/Chart.yaml
+++ b/charts/kompass/Chart.yaml
@@ -3,7 +3,7 @@ name: kompass
 description: Zesty Kompass Helm Charts
 icon: https://zesty.co/wp-content/uploads/2024/05/favicon-150x150.png
 type: application
-version: 0.2.10
+version: 0.2.11
 appVersion: "1.16.0"
 dependencies:
   # zesty products

--- a/charts/kompass/values.yaml
+++ b/charts/kompass/values.yaml
@@ -627,7 +627,7 @@ kubeStateMetrics:
       - watch
 
 grafana:
-  enabled: false
+  enabled: true
   fullnameOverride: "kompass-grafana"
   # Pod-level security context applied to the Grafana pod.
   # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
## Summary
- Enable Grafana by default in the Kompass Helm chart values.

## Testing
- Not run; configuration-only default change.