### PR TITLE
feat: Empty string in pod_placement_evictability (KPS-5987)

### DIFF
--- a/charts/kompass/Chart.yaml
+++ b/charts/kompass/Chart.yaml
@@ -3,14 +3,14 @@ name: kompass
 description: Zesty Kompass Helm Charts
 icon: https://zesty.co/wp-content/uploads/2024/05/favicon-150x150.png
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: "1.16.0"
 dependencies:
   # zesty products
   - name: kompass-insights
     condition: kompass-insights.enabled
     repository: "https://zesty-co.github.io/kompass"
-    version: "2.1.96"
+    version: "2.2.6"
   - name: pod-rightsizing
     alias: rightsizing
     repository: "https://zesty-co.github.io/kompass-pod-rightsizing"

--- a/charts/kompass/files/custom-vm-recording-rules.yaml
+++ b/charts/kompass/files/custom-vm-recording-rules.yaml
@@ -99,3 +99,14 @@ groups:
           max by(container,pod,namespace,created_by_name,created_by_kind,capacity_type,resource_id,status) (
             kompass_insights_pod_info{status="running"}
           )
+      {{- if index .Values "kompass-pod-placement" "enabled" }}
+      # kompass_pod_placement_pod_info is returned by all pod-placement pods
+      # `max without()` is used to deduplicate metrics from multiple instances/pods
+      - record: kompass_pod_placement_pod_info_extended
+        expr: >-
+          max without(instance,job) (kompass_pod_placement_pod_info)
+            * on(pod,namespace) group_left(created_by_name,created_by_kind,capacity_type,resource_id,status)
+          max by(pod,namespace,created_by_name,created_by_kind,capacity_type,resource_id,status) (
+            kompass_insights_pod_info{status="running"}
+          )
+      {{- end }}

--- a/charts/kompass/templates/_helpers.tpl
+++ b/charts/kompass/templates/_helpers.tpl
@@ -284,6 +284,16 @@ Global value takes precedence when explicitly set.
 {{- end -}}
 
 {{/*
+Returns Kompass Pod Placement name
+*/}}
+{{- define "kompass.pod-placement.name" -}}
+  {{- if and .Values.kubeStateMetrics.enabled -}}
+  {{- $ctx := dict "Values" (index .Values "kompass-pod-placement") "Chart" (index .Subcharts "kompass-pod-placement" "Chart") "Release" .Release -}}
+  {{- include "kompass-pod-placement.name" $ctx -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Returns Kompass Pod Placement selector labels
 */}}
 {{- define "kompass.pod-placement.selectorLabels" -}}

--- a/charts/kompass/templates/dependencies/vm-configs.yaml
+++ b/charts/kompass/templates/dependencies/vm-configs.yaml
@@ -184,6 +184,27 @@ data:
             regex: '{{ include "kompass.kube-state-metrics.keepRegex" . }}'
             action: keep
 
+      {{- if index .Values "kompass-pod-placement" "enabled" }}
+      # for collecting pod-placement metrics
+      - job_name: 'pod-placement'
+        scrape_interval: {{ include "kompass.scrapeInterval" . }}
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - {{ .Release.Namespace }}
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+            regex: {{ include "kompass.pod-placement.name" . }}
+            action: keep
+          - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
+            regex: {{ .Release.Name }}
+            action: keep
+          - source_labels: [__meta_kubernetes_pod_container_port_name]
+            regex: metrics
+            action: keep
+      {{- end }}
+
       #  vmagent's own metrics
       - job_name: 'vmagent'
         scrape_interval: {{ include "kompass.scrapeInterval" . }}


### PR DESCRIPTION
- Scrape `kompass_pod_placement_pod_info` metric from kompass-pod-placement
- Add recording rule `kompass_pod_placement_pod_info_extended` to extend `kompass_pod_placement_pod_info` with `kompass_insights_pod_info` metric