### PR TITLE
Update rightsizing permissions for insights

### DIFF
--- a/charts/kompass-insights/Chart.yaml
+++ b/charts/kompass-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kompass-insights
 description: Kompass Insights for K8s
 type: application
-version: 2.2.8
+version: 2.2.9
 appVersion: "v1.162.1"
 
 dependencies:

--- a/charts/kompass-insights/templates/clusterRole.yaml
+++ b/charts/kompass-insights/templates/clusterRole.yaml
@@ -11,10 +11,7 @@ rules:
     resources:
       - policies
       - actions
-    verbs:
-      - get
-      - list
-      - watch
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups:
       - "horizontalscaling.kompass.zesty.co"
     resources:


### PR DESCRIPTION
## Summary
- Grant Kompass Insights write permissions for rightsizing policies and actions.
- Bump the kompass-insights chart version to 2.2.9.

## Validation
- helm lint charts/kompass-insights