### PR TITLE
feat: add endpoints read access to kompass insights

### DIFF
--- a/charts/kompass-insights/Chart.yaml
+++ b/charts/kompass-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kompass-insights
 description: Kompass Insights for K8s
 type: application
-version: 2.2.12
+version: 2.2.13
 appVersion: "v1.164.1"
 
 dependencies:

--- a/charts/kompass-insights/templates/clusterRole.yaml
+++ b/charts/kompass-insights/templates/clusterRole.yaml
@@ -125,6 +125,7 @@ rules:
       - pods
       - replicationcontrollers
       - services
+      - endpoints
       - nodes/proxy
     {{- include "zesty-k8s.verbs" . | nindent 4 }}
   - apiGroups:


### PR DESCRIPTION
## Summary
- Add Kubernetes core `endpoints` read access to the kompass-insights ClusterRole.
- Bump kompass-insights chart version from `2.2.12` to `2.2.13`.

## Validation
- `git diff --check -- charts/kompass-insights/templates/clusterRole.yaml charts/kompass-insights/Chart.yaml`