### PR TITLE
fix(victoria-metrics-agent): add nodes/proxy RBAC permission

### DIFF
--- a/charts/kompass/values.yaml
+++ b/charts/kompass/values.yaml
@@ -499,6 +499,12 @@ victoriaMetricsAgent:
   remoteWrite:
   - url: *vmRemoteWritePrometheusUrl
 
+  rbac:
+    extraRules:
+    - apiGroups: [""]
+      resources:
+      - nodes/proxy
+      verbs: ["get"]
 victoriaMetricsAlert:
   enabled: true
   fullnameOverride: kompass-victoria-metrics-alert


### PR DESCRIPTION
## Description
Fixes KPS-6424

Victoria Metrics Agent is failing to scrape kubelet resource metrics in all clusters due to insufficient RBAC permissions. The agent receives a 403 Forbidden response when attempting to access .

## Root Cause
The ClusterRole for the victoria-metrics-agent service account has permissions for `nodes` and `nodes/metrics`, but is missing `nodes/proxy`.

## Solution
This PR adds the missing `nodes/proxy` permission to the ClusterRole via the `rbac.extraRules` configuration in the victoriaMetricsAgent section.

## Testing
After this change is deployed:
- Victoria Metrics Agent should successfully scrape kubelet resource metrics
- No 403 Forbidden errors should appear in the agent logs
- The `kubelet-resource` scrape target should report healthy

## Related Issue
https://zestyco.atlassian.net/browse/KPS-6424