### PR TITLE
KPS-6658 Custom pricing

### DIFF
--- a/charts/kompass-insights/Chart.yaml
+++ b/charts/kompass-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kompass-insights
 description: Kompass Insights for K8s
 type: application
-version: 2.2.14
+version: 2.2.15
 appVersion: "v1.164.1"
 
 dependencies:

--- a/charts/kompass-insights/templates/configMap.yaml
+++ b/charts/kompass-insights/templates/configMap.yaml
@@ -10,6 +10,7 @@ data:
   ORG_ID: "{{ .Values.orgID }}"
   PODMINUTEMETRICS_ENABLED: "{{ .Values.podMinuteMetrics.enabled }}"
   PATHS_MOUNTPATH: "{{ .Values.persistence.mountPath }}"
+  PATHS_PRICINGCONFIGPATH: "/var/configs/pricing/pricing.json"
   STORAGE_SIZE: "{{ .Values.persistence.spec.resources.requests.storage }}"
   EXTERNAL_ID: "{{ .Values.externalID }}"
   {{- if .Values.prometheus.url }}

--- a/charts/kompass-insights/templates/deployment.yaml
+++ b/charts/kompass-insights/templates/deployment.yaml
@@ -86,6 +86,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
+        checksum/pricing-config: {{ include (print $.Template.BasePath "/pricing-configmap.yaml") . | sha256sum }}
         {{- with $insightsPodAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -178,6 +179,9 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.persistence.mountPath }}
               name: {{ .Values.persistence.volumeName }}
+            - mountPath: /var/configs/pricing
+              name: pricing-config
+              readOnly: true
           envFrom:
             - configMapRef:
                 name: "{{ include "zesty-k8s.configmap" . }}"
@@ -232,3 +236,7 @@ spec:
           emptyDir: {}
         - name: migrate-cache
           emptyDir: {}
+        - name: pricing-config
+          configMap:
+            name: kompass-pricing-config
+            optional: true

--- a/charts/kompass-insights/templates/pricing-configmap.yaml
+++ b/charts/kompass-insights/templates/pricing-configmap.yaml
@@ -1,0 +1,26 @@
+{{- /*
+  Per-cluster pricing rates rendered into the shape OpenCost expects for its
+  CustomPricing struct, then mounted into the insights-agent pod at
+  /var/configs/pricing/pricing.json.
+
+  Empty CPU/RAM values intentionally render through and mean no custom pricing.
+  Partial CPU/RAM values also render through so the agent can report the invalid
+  pricing configuration while retaining any last-known-good prices.
+*/}}
+{{- $pricing := .Values.pricing | default dict }}
+{{- $pricingConfig := deepCopy ((get $pricing "config") | default dict) }}
+{{- $_ := set $pricingConfig "provider" "custom" }}
+{{- $_ := set $pricingConfig "currencyCode" "USD" }}
+{{- $_ := set $pricingConfig "customPricesEnabled" "true" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kompass-pricing-config
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/instance: "{{ include "zesty-k8s.fullname" . }}"
+    app.kubernetes.io/name: "{{ include "zesty-k8s.fullname" . }}"
+    app.kubernetes.io/component: pricing-config
+data:
+  pricing.json: |-
+{{ toPrettyJson $pricingConfig | indent 4 }}

--- a/charts/kompass-insights/values.yaml
+++ b/charts/kompass-insights/values.yaml
@@ -119,6 +119,13 @@ config:
 podMinuteMetrics:
   enabled: true
 
+pricing:
+  config:
+    CPU: ""
+    RAM: ""
+    spotCPU: ""
+    spotRAM: ""
+
 insights:
   extraEnv: []
 


### PR DESCRIPTION
## Summary
- add a chart-owned `kompass-pricing-config` ConfigMap that renders `pricing.json` for the insights agent
- mount the pricing config at `/var/configs/pricing` and expose `PATHS_PRICINGCONFIGPATH`
- keep only editable CPU/RAM and spot CPU/RAM values in `values.yaml`, with fixed USD/custom-prices metadata rendered by the chart

## Old PR #259 audit
Reused:
- pricing ConfigMap concept and `pricing.json` shape
- insights deployment mount at `/var/configs/pricing`
- pricing config path wiring for the agent

Intentionally not reused:
- `pricing.enabled`, because KPS-6658 requires removing the feature flag
- `pricing.configMapName`, because KPS-6658 requires fixed chart-owned name `kompass-pricing-config`
- exposed `currencyCode` and `customPricesEnabled`, because KPS-6658 requires chart-owned `USD` and `true`
- Helm `required`/`fail` validation, because empty values and partial CPU/RAM must render through for agent-side behavior
- unrelated old-branch drift in Coralogix helpers, RBAC endpoints, `BRIDGE_ENABLED`, and older chart/app versions

## Validation
- `helm lint charts/kompass-insights` passes; only existing dependency warning for missing vendored `kompass-admission-controller`
- rendered defaults, valid CPU/RAM, partial CPU-only, config path, and deployment mount with dependencies built in `/tmp`
