### PR TITLE
feat: Add support of OpenShift

### DIFF
--- a/charts/kompass-insights/Chart.yaml
+++ b/charts/kompass-insights/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kompass-insights
 description: Kompass Insights for K8s
 type: application
-version: 2.3.3
+version: 2.3.4
 appVersion: "v1.166.0"
 
 dependencies:
@@ -10,4 +10,4 @@ dependencies:
     alias: admission
     condition: admission.enabled
     repository: https://zesty-co.github.io/kompass-admission-controller
-    version: 0.1.20
+    version: 0.1.21

--- a/charts/kompass-insights/templates/_helpers.tpl
+++ b/charts/kompass-insights/templates/_helpers.tpl
@@ -517,3 +517,24 @@ Validate custom pricing configuration.
 {{- include "zesty-k8s.validate.pricingNumber" (dict "name" "customPricing.spotCpu" "value" (get $pricing "spotCpu") "optional" true "positive" true) -}}
 {{- include "zesty-k8s.validate.pricingNumber" (dict "name" "customPricing.spotRam" "value" (get $pricing "spotRam") "optional" true "positive" true) -}}
 {{- end -}}
+
+{{- define "zesty-k8s.isOpenShift" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $toggle := get $global "openShift" -}}
+{{- if kindIs "bool" $toggle -}}
+  {{- if $toggle -}}true{{- end -}}
+{{- else -}}
+  {{- if or (.Capabilities.APIVersions.Has "security.openshift.io/v1") (.Capabilities.APIVersions.Has "route.openshift.io/v1") -}}true{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "zesty-k8s.workload.defaultPodSecurityContext" -}}
+{{- if not (include "zesty-k8s.isOpenShift" .) -}}
+fsGroup: 65532
+runAsGroup: 65532
+runAsNonRoot: true
+runAsUser: 65532
+seccompProfile:
+  type: RuntimeDefault
+{{- end -}}
+{{- end -}}

--- a/charts/kompass-insights/templates/clusterRole.yaml
+++ b/charts/kompass-insights/templates/clusterRole.yaml
@@ -212,4 +212,23 @@ rules:
       - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
     {{- include "zesty-k8s.verbs" . | nindent 4 }}
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - dnses
+      - clusterversions
+    verbs:
+    {{- include "zesty-k8s.verbs" . | nindent 4 }}
+  - apiGroups:
+      - machine.openshift.io
+    resources:
+      - machinesets
+      - controlplanemachinesets
+    {{- include "zesty-k8s.verbs" . | nindent 4 }}
+  - apiGroups:
+      - autoscaling.openshift.io
+    resources:
+      - machineautoscalers
+      - clusterautoscalers
+    {{- include "zesty-k8s.verbs" . | nindent 4 }}
   {{- end }}

--- a/charts/kompass-insights/templates/deployment.yaml
+++ b/charts/kompass-insights/templates/deployment.yaml
@@ -12,9 +12,13 @@
   "key" "podLabels"
   "fallback" (.Values.insights.podLabels | default dict)
 ) | fromYaml -}}
+{{- $insightsDefaultPodSC := include "zesty-k8s.workload.defaultPodSecurityContext" . | fromYaml -}}
 {{- $insightsResolvedPodSecurityContext := mergeOverwrite
   (mergeOverwrite
-    (deepCopy (.Values.securityContext | default dict))
+    (mergeOverwrite
+      (deepCopy ($insightsDefaultPodSC | default dict))
+      (.Values.securityContext | default dict)
+    )
     ((get $insightsWorkload "podSecurityContext") | default dict)
   )
   ((get $globalWorkload "podSecurityContext") | default dict)
@@ -133,13 +137,11 @@ spec:
               name: {{ .Values.persistence.volumeName }}
             - mountPath: /tmp
               name: migrate-tmp
-            - mountPath: /home/nonroot/.cache
-              name: migrate-cache
           env:
             - name: TMPDIR
               value: /tmp
             - name: XDG_CACHE_HOME
-              value: /home/nonroot/.cache
+              value: /tmp/.cache
           args: ["schema", "apply", "--url", "sqlite://{{ .Values.persistence.mountPath}}/zesty.db", "--dev-url", "sqlite://dev?mode=memory", "--to",  "file:///bin/pkg/db/schema.sql", "--auto-approve", "--format", "json"]
       containers:
         - image: "{{ .Values.image.repository }}:{{ include "zesty-k8s.version" . }}"
@@ -223,6 +225,4 @@ spec:
           persistentVolumeClaim:
             claimName: "{{ include "zesty-k8s.pvcname" . }}"
         - name: migrate-tmp
-          emptyDir: {}
-        - name: migrate-cache
           emptyDir: {}

--- a/charts/kompass-insights/templates/monitoring/cluster_role.yaml
+++ b/charts/kompass-insights/templates/monitoring/cluster_role.yaml
@@ -48,5 +48,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - dnses
+  - clusterversions
+  verbs:
+  - get
 {{- end }}
-  

--- a/charts/kompass-insights/templates/recommendations-deployment.yaml
+++ b/charts/kompass-insights/templates/recommendations-deployment.yaml
@@ -14,9 +14,13 @@
   "key" "podLabels"
   "fallback" (.Values.recommendations.podLabels | default dict)
 ) | fromYaml -}}
+{{- $recommendationsDefaultPodSC := include "zesty-k8s.workload.defaultPodSecurityContext" . | fromYaml -}}
 {{- $recommendationsResolvedPodSecurityContext := mergeOverwrite
   (mergeOverwrite
-    (deepCopy (.Values.recommendations.podSecurityContext | default dict))
+    (mergeOverwrite
+      (deepCopy ($recommendationsDefaultPodSC | default dict))
+      (.Values.recommendations.podSecurityContext | default dict)
+    )
     ((get $recommendationsWorkload "podSecurityContext") | default dict)
   )
   ((get $globalWorkload "podSecurityContext") | default dict)

--- a/charts/kompass-insights/values.yaml
+++ b/charts/kompass-insights/values.yaml
@@ -15,6 +15,8 @@ global:
   imagePullSecret:
     name: ""
     dockerconfigjson: ""
+  # When null, auto-detect OpenShift via its API groups. Set true/false to force.
+  openShift: ~
 
 orgID: ""
 # Plaintext encrypted credentials value.
@@ -69,13 +71,8 @@ container:
         - ALL
     readOnlyRootFilesystem: true
 
-securityContext:
-  fsGroup: 65532
-  runAsGroup: 65532
-  runAsNonRoot: true
-  runAsUser: 65532
-  seccompProfile:
-    type: RuntimeDefault
+# Default pod securityContext (fsGroup/runAsUser/etc.) lives in the template and is skipped on OpenShift.
+securityContext: {}
 
 resources:
   limits:
@@ -180,13 +177,8 @@ recommendations:
   podAnnotations: {}
   podLabels: {}
   # Pod-level settings. These take precedence over legacy pod keys under `securityContext`.
-  podSecurityContext:
-    fsGroup: 65532
-    runAsGroup: 65532
-    runAsNonRoot: true
-    runAsUser: 65532
-    seccompProfile:
-      type: RuntimeDefault
+  # Default pod securityContext (fsGroup/runAsUser/etc.) lives in the template and is skipped on OpenShift.
+  podSecurityContext: {}
   runtimeClassName: ~
   # Container-level settings. Legacy pod-level keys mixed here are tolerated and moved to pod securityContext.
   securityContext:

--- a/charts/kompass-pod-placement/Chart.yaml
+++ b/charts/kompass-pod-placement/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kompass-pod-placement
 description: Zesty Kompass Pod Placement for K8s
 type: application
-version: 0.1.18
+version: 0.1.19
 appVersion: "v0.5.1"

--- a/charts/kompass-pod-placement/templates/_helpers.tpl
+++ b/charts/kompass-pod-placement/templates/_helpers.tpl
@@ -69,3 +69,42 @@ Create image reference
 {{- define "kompass-pod-placement.webhook.certificateName" -}}
 {{ include "kompass-pod-placement.fullname" . }}-webhook-cert
 {{- end }}
+
+{{- define "kompass-pod-placement.isOpenShift" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $toggle := get $global "openShift" -}}
+{{- if kindIs "bool" $toggle -}}
+  {{- if $toggle -}}true{{- end -}}
+{{- else -}}
+  {{- if or (.Capabilities.APIVersions.Has "security.openshift.io/v1") (.Capabilities.APIVersions.Has "route.openshift.io/v1") -}}true{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kompass-pod-placement.imagePullSecrets" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $globalList := $global.imagePullSecrets | default list -}}
+{{- $componentList := .Values.imagePullSecrets | default list -}}
+{{- $legacyName := (($global.imagePullSecret) | default dict).name | default "" -}}
+{{- $resolved := list -}}
+{{- if gt (len $globalList) 0 -}}
+{{- $resolved = $globalList -}}
+{{- else if gt (len $componentList) 0 -}}
+{{- $resolved = $componentList -}}
+{{- else if ne $legacyName "" -}}
+{{- $resolved = list (dict "name" $legacyName) -}}
+{{- end -}}
+{{- if gt (len $resolved) 0 -}}
+{{- toYaml $resolved -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kompass-pod-placement.defaultPodSecurityContext" -}}
+{{- if not (include "kompass-pod-placement.isOpenShift" .) -}}
+fsGroup: 65532
+runAsGroup: 65532
+runAsNonRoot: true
+runAsUser: 65532
+seccompProfile:
+  type: RuntimeDefault
+{{- end -}}
+{{- end -}}

--- a/charts/kompass-pod-placement/templates/deployment.yaml
+++ b/charts/kompass-pod-placement/templates/deployment.yaml
@@ -25,19 +25,24 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "kompass-pod-placement.fullname" . }}
-      {{- $globalPullSecrets := list }}
-      {{- if .Values.global.imagePullSecret.name }}
-      {{- $globalPullSecrets = append $globalPullSecrets (dict "name" .Values.global.imagePullSecret.name) }}
-      {{- end }}
-      {{- range .Values.global.imagePullSecrets }}
-      {{- $globalPullSecrets = append $globalPullSecrets . }}
-      {{- end }}
-      {{- $pullSecrets := .Values.imagePullSecrets | default $globalPullSecrets }}
+      {{- $pullSecrets := include "kompass-pod-placement.imagePullSecrets" . | fromYamlArray }}
       {{- if $pullSecrets }}
       imagePullSecrets:
         {{- toYaml $pullSecrets | nindent 8 }}
       {{- end }}
-      {{- with .Values.podSecurityContext }}
+      {{- $defaultPodSC := include "kompass-pod-placement.defaultPodSecurityContext" . | fromYaml -}}
+      {{- $podSecurityContext := mergeOverwrite
+        (mergeOverwrite
+          (deepCopy ($defaultPodSC | default dict))
+          (.Values.podSecurityContext | default dict)
+        )
+        (.Values.global.podSecurityContext | default dict)
+      -}}
+      {{- $securityContext := mergeOverwrite
+        (deepCopy (.Values.securityContext | default dict))
+        (.Values.global.securityContext | default dict)
+      -}}
+      {{- with $podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -45,7 +50,7 @@ spec:
         {{- include "kompass-pod-placement.affinity" . | nindent 8 }}
       containers:
         - name: pod-placement
-          {{- with .Values.securityContext }}
+          {{- with $securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/kompass-pod-placement/values.yaml
+++ b/charts/kompass-pod-placement/values.yaml
@@ -1,4 +1,6 @@
 global:
+  # When null, auto-detect OpenShift via its API groups. Set true/false to force.
+  openShift: ~
   cxLogging:
     enabled: false
     clusterName: ""
@@ -117,13 +119,8 @@ cxLogging:
   ingressUrl: https://ingress.eu2.coralogix.com/
   otelEndpoint: ""
 
-podSecurityContext:
-  runAsUser: 1000
-  runAsGroup: 1000
-  fsGroup: 1000
-  runAsNonRoot: true
-  seccompProfile:
-    type: RuntimeDefault
+# Default pod securityContext (fsGroup/runAsUser/etc.) lives in the template and is skipped on OpenShift.
+podSecurityContext: {}
 
 # cache.securityContext -- Security context for the Cache container.
 # See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container


### PR DESCRIPTION
- Add option to detect OpenShift cluster by Helm Chart
- On OpenShift cluster do not set `runAsUser`, `runAsGroup` or `fsGroup`
- Kompass Insights migration container: use `/tmp/` for cache
- Add supoport for OpenShift in pod-placement