### PR TITLE
fix: restore kompass-pod-placement condition with always-on default

### DIFF
--- a/charts/kompass/Chart.yaml
+++ b/charts/kompass/Chart.yaml
@@ -3,7 +3,7 @@ name: kompass
 description: Zesty Kompass Helm Charts
 icon: https://zesty.co/wp-content/uploads/2024/05/favicon-150x150.png
 type: application
-version: 0.2.50
+version: 0.2.51
 appVersion: "1.16.0"
 dependencies:
   # zesty products
@@ -21,6 +21,7 @@ dependencies:
     repository: "https://zesty-co.github.io/zesty-helm"
     version: 1.7.4
   - name: kompass-pod-placement
+    condition: kompass-pod-placement.enabled
     repository: "https://zesty-co.github.io/kompass"
     version: 0.1.18
   # mutual dependencies

--- a/charts/kompass/values.yaml
+++ b/charts/kompass/values.yaml
@@ -243,7 +243,7 @@ disk:
     apiKey: ""
 
 kompass-pod-placement:
-  enabled: false
+  enabled: true
 
 victoriaMetrics:
   enabled: true


### PR DESCRIPTION
## Problem

#317 removed the `condition:` from the `kompass-pod-placement` dependency, so Helm now renders the subchart unconditionally. An explicit `kompass-pod-placement.enabled: false` in user-supplied values is silently ignored — and kompass-onboarding still generates exactly that key today, so every terraform-onboarded install carries a flag that does nothing. The umbrella `values.yaml` also still says `enabled: false`, which is dead configuration.

## Fix

- Restore `condition: kompass-pod-placement.enabled` on the dependency.
- Flip the umbrella default to `enabled: true`.

Net effect: default behavior is unchanged from #317 (pod placement deploys everywhere), but an explicit disable works again and the values file stops lying.

## Coordination

[kompass-onboarding MR !129](https://gitlab.com/zestyco/kompass/kompass-onboarding/-/merge_requests/129) removes the stale `enabled: false` from the generated values. That MR should merge and deploy **before** this chart releases, otherwise terraform-onboarded accounts would get pod placement disabled by their generated values.

Found via the PLAT-124 Terraform onboarding E2E suite, together with two related issues: staging-onboarded accounts get 403 pulling `zesty-k8s/pod-placement` from the prod registry (ECR grant gap), and the `agent:v1.166.0` self-monitoring cron segfaults ([kompass-agent MR !498](https://gitlab.com/zestyco/kompass/kompass-agent/-/merge_requests/498)).